### PR TITLE
Tiledb 2.2.9 fix pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,12 +40,6 @@ requirements:
     - lz4-c
     - aws-sdk-cpp
     - curl         # [not win]
-  run:
-    - zlib
-    - bzip2
-    - zstd
-    - lz4-c
-    - curl         # [not win]
   run_constrained:                                              # [osx]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.12") }}   # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,13 @@ build:
   number: 0
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
-    - {{ pin_subpackage('tiledb', 'x.x') }}
+    - {{ pin_subpackage('tiledb', max_pin='x.x') }}
   skip: true  # [win and vc<14]
 
 requirements:
   build:
-    - cmake
+    # Later versions don't work with current AWS SDK
+    - cmake  <=3.21
     - make         # [not win]
     - pkg-config   # [not win]
     - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     #    - 0001-disable-homebrew-ssl-search-path.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ build:
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}
-  skip: true  # [win and vc<14]
+  # aws-sdk-cpp is not available on s390x and this version was never built there.
+  skip: true  # [win and vc<14 or s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - make         # [not win]
     - pkg-config   # [not win]
     - {{ compiler('cxx') }}
+    - patch        # [not win]
+    - m2-patch     # [win]
   host:
     - zlib
     - bzip2


### PR DESCRIPTION
Even though we have v2.3.3 and don't pin tiledb in cbc.yaml, we seem to end up building against v2.2.9 for some reason (e.g. while building gdal), probably through indirect dependencies.