### PR TITLE
Build for main channel and Windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,31 +3,34 @@ setlocal EnableDelayedExpansion
 REM Copy tiledb-patches to the source directory
 xcopy /Y /S /I "%RECIPE_DIR%\tiledb-patches" "%SRC_DIR%"
 
+REM Regenerate the capnp serialization files with the version installed in Conda.
+REM This allows updating capnproto independently of upstream tiledb.
+%PREFIX%\Library\bin\capnp compile -I %PREFIX%\Library\include -oc++:%SRC_DIR%\tiledb\sm\serialization %SRC_DIR%\tiledb\sm\serialization\tiledb-rest.capnp --src-prefix=%SRC_DIR%\tiledb\sm\serialization
+if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
-REM Ideally, we'd disable vcpkg as it's done in build.sh
-REM but tiledb is using libmagic (aka darwin file command) on windows, with some patches that make it possible...
-
 cmake -G Ninja %CMAKE_ARGS% ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+      -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DTILEDB_CMAKE_IDE=ON ^
       -DTILEDB_WERROR=OFF ^
       -DTILEDB_TESTS=OFF ^
-      -DTILEDB_S3=OFF ^
-      -DTILEDB_AZURE=OFF ^
-      -DTILEDB_WEBP=OFF ^
+      -DTILEDB_S3=ON ^
+      -DTILEDB_AZURE=ON ^
+      -DTILEDB_WEBP=ON ^
       -DTILEDB_HDFS=OFF ^
       -DCOMPILER_SUPPORTS_AVX2=OFF ^
       -DTILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK=ON ^
       -DTILEDB_SERIALIZATION=ON ^
-      -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+      -DTILEDB_DISABLE_AUTO_VCPKG=ON ^
       -DVCPKG_TARGET_TRIPLET=x64-windows ^
       -DVCPKG_CMAKE_CONFIGURE_OPTIONS=-DCMAKE_FIND_DEBUG_MODE=TRUE ^
       ..
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
 cmake --build . -j %CPU_COUNT% --target install
-if errorlevel 1 exit 1
+if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,10 +23,6 @@ if [[ $target_platform =~ osx-arm64 ]]; then
   export LDFLAGS="${LDFLAGS} ${CURL_LIBS_APPEND}"
 fi
 
-if [[ $target_platform  == linux-64 ]]; then
-  export LDFLAGS="${LDFLAGS} -Wl,--no-as-needed"
-fi
-
 if [[ $target_platform == linux-* ]]; then
   export LDFLAGS="${LDFLAGS} -lrt"
 fi
@@ -49,24 +45,12 @@ if [[ $target_platform == linux-aarch64  ]]; then
   export VCPKG_TARGET_TRIPLET="arm64-linux"
 fi
 
-# For snowflake build only, disabling all the ports:
-# Azure, S3 (AWS) and WebP
-# As they don't require them.
-# TODO: Azure and AWS are supported currently on main in previous version.
-# We should follow up on this package to update it properly and upload to defaults.
-
-# Changes required to build with ports:
-# - TILEDB_AZURE, TILEDB_S3, and optionally TILEDB_WEBP set to ON (WebP currently not supported, as it wasn't back then)
-# - TILEDB_DISABLE_AUTO_VCPKG=ON to disable vcpkg download of dependencies
-# I've been able to find following required packages:
-# - azure-core-cpp
-# - azure-identity-cpp
-# - azure-storage-blobs-cpp
-# - aws-sdk-cpp >=1.11.300 # or >=.2xx, when they introduced generated/src/aws-cpp-sdk-s3/include/aws/s3/model/StorageClass.h with SNOW and EXPRESS_ONEZONE StorageClass values, best to take the commit from vcpkg
-# - capnproto 1.0.1 # hard pinned in cpp code
-# - libmagic
-# Then for azure-storage-blobs-cpp we need azure-storage-core-cpp
-# and for aws-sdk-cpp a chain of aws-c-* dependencies
+# Regenerate the capnp serialization files with the version installed in Conda.
+# This allows updating capnproto independently of upstream tiledb.
+if ! $PREFIX/bin/capnp compile -I $PREFIX/include -oc++:$SRC_DIR/tiledb/sm/serialization $SRC_DIR/tiledb/sm/serialization/tiledb-rest.capnp --src-prefix=$SRC_DIR/tiledb/sm/serialization
+then
+  exit 1
+fi
 
 mkdir build && cd build
 cmake -G Ninja ${CMAKE_ARGS} \
@@ -78,11 +62,12 @@ cmake -G Ninja ${CMAKE_ARGS} \
   -DTILEDB_HDFS=ON \
   -DTILEDB_SANITIZER=OFF \
   -DCOMPILER_SUPPORTS_AVX2:BOOL=FALSE \
-  -DTILEDB_S3=OFF \
-  -DTILEDB_AZURE=OFF \
+  -DTILEDB_S3=ON \
+  -DTILEDB_AZURE=ON \
   -DTILEDB_SERIALIZATION=ON \
-  -DTILEDB_WEBP=OFF \
+  -DTILEDB_WEBP=ON \
   -DTILEDB_DISABLE_AUTO_VCPKG=ON \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
+  -DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET} \
   ..
 cmake --build . -j $(( ${CPU_COUNT} / 2 + 1 )) --target install

--- a/recipe/link_test_src/CMakeLists.txt
+++ b/recipe/link_test_src/CMakeLists.txt
@@ -1,0 +1,65 @@
+#
+# CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2018-2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+cmake_minimum_required(VERSION 3.21)
+project(TileDBExampleProj)
+
+# Set C++17 as required standard for all C++ targets (required to use the TileDB
+# C++ API).
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find TileDB.
+#
+# If TileDB is not installed globally on your system, either set
+# CMAKE_PREFIX_PATH on the CMake command line:
+#   $ cmake -DCMAKE_PREFIX_PATH=/path/to/TileDB-installation ..
+# or you can hardcode it here e.g.
+#   list(APPEND CMAKE_PREFIX_PATH "/path/to/TileDB-installation")
+find_package(TileDB
+  ${TILEDB_VERSION} EXACT
+  REQUIRED
+  )
+
+# Set up the example program.
+add_executable(ExampleExe "src/main.cc")
+
+# Link the example program with the TileDB shared library.
+# This also configures include paths to find the TileDB headers.
+target_link_libraries(ExampleExe TileDB::tiledb_shared)
+
+# Link a second executable with the TileDB static library, if it is available.
+# TODO: re-enable this on Windows
+if (NOT WIN32 AND TILEDB_STATIC)
+  add_executable(ExampleExe_static "src/main.cc")
+  target_link_libraries(ExampleExe_static TileDB::tiledb_static)
+endif()
+  # COMMAND ExampleExe
+add_custom_target(
+  link_test
+  $<TARGET_FILE:ExampleExe>
+)

--- a/recipe/link_test_src/README.md
+++ b/recipe/link_test_src/README.md
@@ -1,0 +1,60 @@
+# TileDB Example CMake Usage
+
+This directory contains a minimal example of how to add TileDB as a dependency to your project using CMake.
+
+## Instructions
+
+Follow these instructions to build the example project.
+
+### macOS and Linux
+
+First, build and install TileDB locally:
+
+    $ cd TileDB
+    $ mkdir build
+    $ cd build
+    $ ../bootstrap && make && make install
+
+Now you can build the example project. Note that we are passing the path to the TileDB installation in `CMAKE_PREFIX_PATH`:
+
+    $ cd TileDB/examples/cmake_project
+    $ mkdir build
+    $ cd build
+    $ cmake -DCMAKE_PREFIX_PATH=/path/to/TileDB/dist .. && make
+
+This creates the `ExampleExe` binary in the build directory. You should be able to execute it directly, e.g.:
+
+    $ ./ExampleExe
+    You are using TileDB version 1.3.0
+
+### Windows
+
+In PowerShell, first build and install TileDB locally:
+
+    > cd TileDB
+    > mkdir build
+    > cd build
+    > ..\bootstrap.ps1 
+    > cmake --build . --config Release
+    > cd tiledb
+    > cmake --build . --config Release --target install
+
+Now you can build the example project. Note that we are passing the path to the TileDB installation in `CMAKE_PREFIX_PATH`:
+
+    > cd TileDB\examples\cmake_project
+    > mkdir build
+    > cd build
+    > cmake -A X64 -DCMAKE_PREFIX_PATH=\path\to\TileDB\dist ..
+    > cmake --build . --config Release
+
+This creates the `ExampleExe` binary in the build directory. You should be able to execute it directly, e.g.:
+
+    > .\ExampleExe.exe
+    You are using TileDB version 1.3.0
+
+Note: on Windows, you must explicitly pass the additional CMake argument `-A X64` to specify building the example for 64-bit architectures. This is because the TileDB library is itself only offered in 64-bit.
+
+## Files
+
+- `CMakeLists.txt`: The top-level CMake list file of the example project.
+- `src/main.cc`: The source file for the example executable.

--- a/recipe/link_test_src/src/main.cc
+++ b/recipe/link_test_src/src/main.cc
@@ -1,0 +1,46 @@
+/**
+ * @file   main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the CMake example project for TileDB.
+ */
+
+#include <cassert>
+
+// Include the TileDB C++ API headers
+#include <tiledb/tiledb>
+
+int main(int argc, char** argv) {
+  // Create a TileDB context
+  tiledb::Context ctx;
+  // Print the version
+  auto version = tiledb::version();
+  std::cout << "You are using TileDB version " << std::get<0>(version) << "."
+            << std::get<1>(version) << "." << std::get<2>(version) << std::endl;
+  return 0;
+}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "2.26.2" %}
 
 package:
-  name: tiledb
+  name: {{ name | lower }}
   version: {{ version }}
 
 source:
@@ -10,15 +10,10 @@ source:
   sha256: 255218aebd3ef5af4b8deb3be58f877fda335d5abc1c097a33f6741bf259a68d
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}
-  # Skipping this build for windows as it's not necessary for snowflake
-  # For defaults build this needs to be enabled
-  skip: true  # [win]
-  missing_dso_whitelist:  # [linux and s390x]
-    - $RPATH/ld64.so.1    # [linux and s390x]
   script_env:
     # "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on
     # arm, s390x, ppc64le and riscv platforms."
@@ -37,30 +32,39 @@ requirements:
     - zlib {{ zlib }}
     - bzip2 {{ bzip2 }}
     - zstd {{ zstd }}
-    - lz4-c 1.9.4
-    - libcurl 8.9.1
+    - libcurl {{ libcurl }}
     - openssl {{ openssl }}
     - spdlog 1.11.0
-    - capnproto 1.0.1.1  # originally 1.0.1, but 1.0.1.1 fixes CVE for capnproto
-    - libmagic 5.39  # [not win]
-  run:
-    # our version of spdlog doesn't provide fmt directly (USE_EXTERNAL_FMT is set to ON), and tiledb requires it
-    - fmt
-    - openssl 3.*
+    - capnproto 1.1.0
+    - libmagic 5.46
+    - fmt 9.1
+    - lz4-c 1.9
+    - aws-sdk-cpp 1.11.528
+    - aws-c-common 0.11
+    - aws-crt-cpp 0.31
+    - azure-core-cpp 1.14
+    - azure-identity-cpp 1.10
+    - azure-storage-blobs-cpp 12.13
+    - libwebp-base {{ libwebp }}
 
 test:
+  requires:
+    - {{ compiler('cxx') }}  # [unix]
+    - cmake                  # [unix]
+    - make                   # [unix]
   commands:
     - test -e $PREFIX/include/tiledb/tiledb.h  # [not win]
-    - test -e $PREFIX/include/tiledb/tiledb  # [not win]
+    - test -e $PREFIX/include/tiledb/tiledb    # [not win]
     - test -e $PREFIX/lib/libtiledb$SHLIB_EXT  # [not win]
     - test -e $PREFIX/lib/pkgconfig/tiledb.pc  # [not win]
-    # While this build is skipping windows, I'm leaving those for future reference
-    - if exist %LIBRARY_INC%\\tiledb\\tiledb (exit 0) else (exit 1)  # [win]
+
+    - if exist %LIBRARY_INC%\\tiledb\\tiledb (exit 0) else (exit 1)    # [win]
     - if exist %LIBRARY_INC%\\tiledb\\tiledb.h (exit 0) else (exit 1)  # [win]
-    - if exist %LIBRARY_LIB%\\tiledb.lib (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_LIB%\\tiledb.lib (exit 0) else (exit 1)        # [win]
+    - if exist %LIBRARY_BIN%\\tiledb.dll (exit 0) else (exit 1)        # [win]
+
     - if exist %LIBRARY_LIB%\\cmake\\TileDB\\TileDBConfig.cmake (exit 0) else (exit 1)  # [win]
-    - if exist %PREFIX%\\Library\\bin\\tiledb.dll (exit 0) else (exit 1)  # [win]
-    - if exist %PREFIX%\\Library\\lib\\pkgconfig\\tiledb.pc (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_LIB%\\pkgconfig\\tiledb.pc (exit 0) else (exit 1)               # [win]
 
 about:
   home: https://tiledb.com
@@ -73,10 +77,13 @@ about:
     a novel on-disk format that can effectively store dense and sparse array data with
     support for fast updates and reads. It features excellent compression, and an efficient
     parallel I/O system with high scalability.
-  doc_url: https://docs.tiledb.com
+  doc_url: https://cloud.tiledb.com/academy/home/
   dev_url: https://github.com/TileDB-Inc/TileDB
 
 extra:
+  skip-lints:
+    - has_run_test_and_commands
+    - invalid_url  # https://cloud.tiledb.com/academy/home/ : Not reachable: 405
   recipe-maintainers:
     - stavrospapadopoulos
     - shelnutt2

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This test builds the contents of link_test_src, a simple test executable
+# linked against tiledb. Then runs the executable.
+cmake -B link_test_bld -S $RECIPE_DIR/link_test_src
+cmake --build link_test_bld
+cmake --build link_test_bld --target link_test -v


### PR DESCRIPTION
tiledb 2.26.2 b4

**Destination channel:** defaults

### Links

- [PKG-8047](https://anaconda.atlassian.net/browse/PKG-8047)
- [Upstream repository](https://github.com/TileDB-Inc/TileDB/tree/2.26.2)
- Relevant dependency PRs:
  - AnacondaRecipes/file-feedstock#2
  - AnacondaRecipes/capnproto-feedstock#7
  - AnacondaRecipes/aws-crt-cpp-feedstock#2
  - AnacondaRecipes/aws-sdk-cpp-feedstock#136

### Explanation of changes:

- Enabled Windows build
- Enabled WebP, AWS, and Azure support
- Added smoke test on Unix platforms


[PKG-8047]: https://anaconda.atlassian.net/browse/PKG-8047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ