### PR TITLE
tiledb 2.26.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 255218aebd3ef5af4b8deb3be58f877fda335d5abc1c097a33f6741bf259a68d
 
 build:
-  number: 5
+  number: 6
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}
@@ -26,6 +26,7 @@ requirements:
     - gawk  # [not win]
     - cmake
     - pkg-config  # [not win]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -39,9 +40,9 @@ requirements:
     - libmagic 5.46
     - fmt 9.1
     - lz4-c 1.9
-    - aws-sdk-cpp 1.11.528
-    - aws-c-common 0.12.3
-    - aws-crt-cpp 0.32.10
+    - aws-sdk-cpp 1.11.638
+    - aws-c-common 0.12.4
+    - aws-crt-cpp 0.34.0
     - azure-core-cpp 1.14
     - azure-identity-cpp 1.10
     - azure-storage-blobs-cpp 12.13


### PR DESCRIPTION
tiledb 2.26.2 

**Destination channel:** Defaults

### Links

- [PKG-9493]
- dev_url:        https://github.com/TileDB-Inc/TileDB/tree/2.26.2
- conda_forge:    None
- pypi:           https://pypi.org/project/tiledb/2.26.2
- pypi inspector: https://inspector.pypi.io/project/tiledb/2.26.2

### Explanation of changes:

- new version number
