### PR TITLE
tiledb 2.26.2 rebuild against fmt 11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
   sha256: 255218aebd3ef5af4b8deb3be58f877fda335d5abc1c097a33f6741bf259a68d
 
 build:
-  number: 6
+  number: 7
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=tiledb
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}
   script_env:
     # "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on
-    # arm, s390x, ppc64le and riscv platforms."
-    - VCPKG_FORCE_SYSTEM_BINARIES=1  # [ arm64 or aarch64 or s390x or ppc64le]
+    # arm, ppc64le and riscv platforms."
+    - VCPKG_FORCE_SYSTEM_BINARIES=1  # [ arm64 or aarch64 or ppc64le]
 
 requirements:
   build:
@@ -38,7 +38,7 @@ requirements:
     - spdlog 1.11.0
     - capnproto 1.1.0
     - libmagic 5.46
-    - fmt 9.1
+    - fmt {{ fmt }}
     - lz4-c 1.9
     - aws-sdk-cpp 1.11.638
     - aws-c-common 0.12.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - zstd {{ zstd }}
     - libcurl {{ libcurl }}
     - openssl {{ openssl }}
-    - spdlog 1.11.0
+    - spdlog 1.15.3
     - capnproto 1.1.0
     - libmagic 5.46
     - fmt {{ fmt }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,8 @@ build:
     - {{ pin_subpackage('tiledb', max_pin='x.x') }}
   script_env:
     # "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on
-    # arm, ppc64le and riscv platforms."
-    - VCPKG_FORCE_SYSTEM_BINARIES=1  # [ arm64 or aarch64 or ppc64le]
+    # arm and riscv platforms."
+    - VCPKG_FORCE_SYSTEM_BINARIES=1  # [ arm64 or aarch64 ]
 
 requirements:
   build:


### PR DESCRIPTION
tiledb 2.26.2 

**Destination channel:** Defaults

### Links

- [PKG-9562]
- dev_url:        https://github.com/TileDB-Inc/TileDB/tree/2.26.2
- conda_forge:    n/a
- pypi:           https://pypi.org/project/tiledb/2.26.2
- pypi inspector: https://inspector.pypi.io/project/tiledb/2.26.2

### Explanation of changes:

- rebuild against fmt 11


[PKG-9562]: https://anaconda.atlassian.net/browse/PKG-9562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ